### PR TITLE
Add support for Laravel 8 factories

### DIFF
--- a/src/Http/Controllers/CypressController.php
+++ b/src/Http/Controllers/CypressController.php
@@ -46,20 +46,7 @@ class CypressController
         $quantity = $request->input('quantity');
         $attributes = $request->input('attributes', []);
 
-        return $this->createModel($modelClass, $quantity, $attributes);
-    }
-
-    private function createModel($modelClass, $quantity = 1, $attributes = [])
-    {
-        if (method_exists($modelClass, 'factory')) {
-            return $modelClass::factory()->count($quantity)->create($attributes);
-        }
-
-        if (function_exists('factory')) {
-            return factory($modelClass, $quantity)->create($attributes);
-        }
-
-        throw new Exception("Unable to locate factory for {$modelClass}.");
+        return $this->createModelsUsingFactory($modelClass, $quantity, $attributes);
     }
 
     public function callArtisan(Request $request)
@@ -74,5 +61,18 @@ class CypressController
         $request->validate(['command' => 'required']);
 
         return Cypress::handleCommand($request->get('command'), $request->get('arguments', []));
+    }
+
+    private function createModelsUsingFactory($modelClass, $quantity = 1, $attributes = [])
+    {
+        if (method_exists($modelClass, 'factory')) {
+            return $modelClass::factory()->count($quantity)->create($attributes);
+        }
+
+        if (function_exists('factory')) {
+            return factory($modelClass, $quantity)->create($attributes);
+        }
+
+        throw new Exception("Unable to locate factory for {$modelClass}.");
     }
 }

--- a/src/Http/Controllers/CypressController.php
+++ b/src/Http/Controllers/CypressController.php
@@ -46,7 +46,20 @@ class CypressController
         $quantity = $request->input('quantity');
         $attributes = $request->input('attributes', []);
 
-        return factory($modelClass, $quantity)->create($attributes);
+        return $this->createModel($modelClass, $quantity, $attributes);
+    }
+
+    private function createModel($modelClass, $quantity = 1, $attributes = [])
+    {
+        if (method_exists($modelClass, 'factory')) {
+            return $modelClass::factory()->count($quantity)->create($attributes);
+        }
+
+        if (function_exists('factory')) {
+            return factory($modelClass, $quantity)->create($attributes);
+        }
+
+        throw new Exception("Unable to locate factory for {$modelClass}.");
     }
 
     public function callArtisan(Request $request)


### PR DESCRIPTION
This PR will allow the package to be used in Laravel 8. The `createModels` method will now try to create a model using Laravel 8's new factories by first checking if the method `factory` exists on the model. If it can't find the `factory` method, it will then check if the global function `factory` exists. This is necessary because, Laravel 8 has removed this global function and support for it is only available through the [laravel/legacy-factories](https://github.com/laravel/legacy-factories) package. If it fails to find both the `factory` method or `factory` global function, it will throw an exception. It's possible that this method might not exist on Laravel 8 models if the model isn't using the `HasFactory` trait.